### PR TITLE
Fix latent NameErrors + logic bugs surfaced by ctx conversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,8 @@ python_version = "3.12"
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
 addopts = "-v --cov=rom24 --cov-report=term-missing"
+
+[dependency-groups]
+dev = [
+    "pyflakes>=3.4.0",
+]

--- a/src/packs/core/commands/do_log.py
+++ b/src/packs/core/commands/do_log.py
@@ -9,7 +9,12 @@ from rom24 import game_utils
 from rom24 import state_checks
 
 
+# Module-level toggle for "log all players" (stock ROM's global fLogAll).
+fLogAll = False
+
+
 def do_log(ctx):
+    global fLogAll
     ch = ctx.ch
     argument = ctx.arg
     argument, arg = game_utils.read_word(argument)
@@ -17,7 +22,6 @@ def do_log(ctx):
         ch.send("Log whom?\n")
         return
     if arg == "all":
-        # TODO: fix this by either adding it to merc, or figuring out an alternative
         if fLogAll:
             fLogAll = False
             ch.send("Log ALL off.\n")

--- a/src/packs/core/commands/do_oset.py
+++ b/src/packs/core/commands/do_oset.py
@@ -27,7 +27,7 @@ def do_oset(ctx):
         ch.send("Nothing like that in heaven or earth.\n")
         return
     # Snarf the value (which need not be numeric).
-    value = int(arg3) if arg3.isdigit else -1
+    value = int(arg3) if arg3.isdigit() else -1
     if value == -1:
         ch.do_oset("")
     # Set something.

--- a/src/packs/core/commands/do_pick.py
+++ b/src/packs/core/commands/do_pick.py
@@ -113,7 +113,7 @@ def do_pick(ctx):
             ch.send("*Click*\n")
             handler_game.act("$n picks the $d.", ch, None, pexit.keyword, merc.TO_ROOM)
             if ch.is_pc:
-                ch.check_improve("pick_lock", True, 2)
+                ch.check_improve("pick lock", True, 2)
 
             # unlock the other side
             to_room = pexit.to_room

--- a/src/packs/core/spells/spell_call_lightning.py
+++ b/src/packs/core/spells/spell_call_lightning.py
@@ -6,6 +6,7 @@ from rom24 import handler_game
 from rom24 import handler_magic
 from rom24 import merc
 from rom24 import state_checks
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_calm.py
+++ b/src/packs/core/spells/spell_calm.py
@@ -6,6 +6,7 @@ from rom24 import fight
 from rom24 import handler_game
 from rom24 import merc
 from rom24 import state_checks
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_chain_lightning.py
+++ b/src/packs/core/spells/spell_chain_lightning.py
@@ -5,6 +5,7 @@ from rom24 import game_utils
 from rom24 import handler_game
 from rom24 import handler_magic
 from rom24 import merc
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_continual_light.py
+++ b/src/packs/core/spells/spell_continual_light.py
@@ -4,6 +4,7 @@ from rom24 import handler_game
 from rom24 import merc
 from rom24 import object_creator
 from rom24 import state_checks
+from rom24 import instance
 
 
 @api.spell(
@@ -32,11 +33,11 @@ def spell_continual_light(ctx):
             ch.send("You don't see that here.\n")
             return
 
-        if item.flags.glow:
+        if light.flags.glow:
             handler_game.act("$p is already glowing.", ch, light, None, merc.TO_CHAR)
             return
 
-        item.flags.glow = True
+        light.flags.glow = True
         handler_game.act("$p glows with a white light.", ch, light, None, merc.TO_ALL)
         return
 

--- a/src/packs/core/spells/spell_create_food.py
+++ b/src/packs/core/spells/spell_create_food.py
@@ -3,6 +3,7 @@ from rom24 import const
 from rom24 import handler_game
 from rom24 import merc
 from rom24 import object_creator
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_create_rose.py
+++ b/src/packs/core/spells/spell_create_rose.py
@@ -3,6 +3,7 @@ from rom24 import const
 from rom24 import handler_game
 from rom24 import merc
 from rom24 import object_creator
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_create_spring.py
+++ b/src/packs/core/spells/spell_create_spring.py
@@ -3,6 +3,7 @@ from rom24 import const
 from rom24 import handler_game
 from rom24 import merc
 from rom24 import object_creator
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_create_water.py
+++ b/src/packs/core/spells/spell_create_water.py
@@ -28,7 +28,7 @@ def spell_create_water(ctx):
         ch.send("It is unable to hold water.\n")
         return
 
-    if obj.value[2] != LIQ_WATER and obj.value[1] != 0:
+    if obj.value[2] != 0 and obj.value[1] != 0:
         ch.send("It contains some other liquid.\n")
         return
 
@@ -38,7 +38,7 @@ def spell_create_water(ctx):
     )
 
     if water > 0:
-        obj.value[2] = LIQ_WATER
+        obj.value[2] = 0
         obj.value[1] += water
         if "water" in obj.name.lower():
             obj.name = "%s water" % obj.name

--- a/src/packs/core/spells/spell_detect_poison.py
+++ b/src/packs/core/spells/spell_detect_poison.py
@@ -22,7 +22,8 @@ def spell_detect_poison(ctx):
     ch = ctx.ch
     victim = ctx.target
     target = ctx.target_type
-    if victim.item_type == merc.ITEM_DRINK_CON or obj.item_type == merc.ITEM_FOOD:
+    obj = victim  # TAR_OBJ_INV: the target is the object
+    if obj.item_type == merc.ITEM_DRINK_CON or obj.item_type == merc.ITEM_FOOD:
         if obj.value[3] != 0:
             ch.send("You smell poisonous fumes.\n")
         else:

--- a/src/packs/core/spells/spell_dispel_magic.py
+++ b/src/packs/core/spells/spell_dispel_magic.py
@@ -64,6 +64,7 @@ def spell_dispel_magic(ctx):
         "weaken": "$n looks stronger.",
     }
 
+    found = False
     for k, v in spells.items():
         if handler_magic.check_dispel(level, victim, const.skill_table[k]):
             if v:

--- a/src/packs/core/spells/spell_earthquake.py
+++ b/src/packs/core/spells/spell_earthquake.py
@@ -5,6 +5,7 @@ from rom24 import game_utils
 from rom24 import handler_game
 from rom24 import merc
 from rom24 import state_checks
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_faerie_fog.py
+++ b/src/packs/core/spells/spell_faerie_fog.py
@@ -4,6 +4,7 @@ from rom24 import handler_game
 from rom24 import handler_magic
 from rom24 import merc
 from rom24 import state_checks
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_floating_disc.py
+++ b/src/packs/core/spells/spell_floating_disc.py
@@ -6,6 +6,7 @@ from rom24 import handler_game
 from rom24 import merc
 from rom24 import object_creator
 from rom24 import state_checks
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_gas_breath.py
+++ b/src/packs/core/spells/spell_gas_breath.py
@@ -8,6 +8,7 @@ from rom24 import game_utils
 from rom24 import handler_game
 from rom24 import handler_magic
 from rom24 import merc
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_gate.py
+++ b/src/packs/core/spells/spell_gate.py
@@ -4,6 +4,7 @@ from rom24 import handler_game
 from rom24 import handler_magic
 from rom24 import merc
 from rom24 import state_checks
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_heat_metal.py
+++ b/src/packs/core/spells/spell_heat_metal.py
@@ -7,6 +7,7 @@ from rom24 import handler_game
 from rom24 import handler_magic
 from rom24 import merc
 from rom24 import state_checks
+from rom24 import instance
 
 
 @api.spell(
@@ -29,6 +30,7 @@ def spell_heat_metal(ctx):
     victim = ctx.target
     target = ctx.target_type
     fail = True
+    dam = 0
 
     if not handler_magic.saves_spell(
         level + 2, victim, merc.DAM_FIRE

--- a/src/packs/core/spells/spell_holy_word.py
+++ b/src/packs/core/spells/spell_holy_word.py
@@ -5,6 +5,7 @@ from rom24 import game_utils
 from rom24 import handler_game
 from rom24 import merc
 from rom24 import state_checks
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_locate_object.py
+++ b/src/packs/core/spells/spell_locate_object.py
@@ -5,6 +5,7 @@ from rom24 import game_utils
 from rom24 import handler_magic
 from rom24 import merc
 from rom24 import state_checks
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_mass_healing.py
+++ b/src/packs/core/spells/spell_mass_healing.py
@@ -2,6 +2,7 @@ from rom24 import api
 from rom24 import const
 from rom24 import merc
 from rom24 import state_checks
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_mass_invis.py
+++ b/src/packs/core/spells/spell_mass_invis.py
@@ -3,6 +3,7 @@ from rom24 import const
 from rom24 import handler_game
 from rom24 import merc
 from rom24 import state_checks
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_nexus.py
+++ b/src/packs/core/spells/spell_nexus.py
@@ -5,6 +5,7 @@ from rom24 import handler_magic
 from rom24 import merc
 from rom24 import object_creator
 from rom24 import state_checks
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_portal.py
+++ b/src/packs/core/spells/spell_portal.py
@@ -5,6 +5,7 @@ from rom24 import handler_magic
 from rom24 import merc
 from rom24 import object_creator
 from rom24 import state_checks
+from rom24 import instance
 
 
 @api.spell(

--- a/src/packs/core/spells/spell_ventriloquate.py
+++ b/src/packs/core/spells/spell_ventriloquate.py
@@ -2,6 +2,7 @@ from rom24 import game_utils
 from rom24 import handler_magic
 from rom24 import merc
 from rom24 import state_checks
+from rom24 import instance
 
 
 def spell_ventriloquate(ctx):
@@ -10,13 +11,13 @@ def spell_ventriloquate(ctx):
     ch = ctx.ch
     victim = ctx.target
     target = ctx.target_type
-    target_name, speaker = game_utils.read_word(target_name)
+    target_name, speaker = game_utils.read_word(target)
     buf1 = "%s says '%s'.\n" % (speaker.capitalize(), target_name)
     buf2 = "Someone makes %s say '%s'.\n" % (speaker, target_name)
 
     for vch_id in ch.in_room.people:
         vch = instance.characters[vch_id]
-        if not is_exact_name(speaker, vch.name) and state_checks.IS_AWAKE(vch):
+        if not game_utils.is_name(speaker, vch.name) and state_checks.IS_AWAKE(vch):
             vch.send(
                 buf2 if handler_magic.saves_spell(level, vch, merc.DAM_OTHER) else buf1
             )

--- a/tests/test_no_undefined_names.py
+++ b/tests/test_no_undefined_names.py
@@ -1,0 +1,41 @@
+"""Static guard: no undefined names in shipped command/spell/prog code.
+
+Undefined names (e.g. a spell body using ``instance`` without importing it, or a
+stray ``obj``) are latent NameErrors that only fire when the command/spell runs,
+so they slip past import and most tests. pyflakes catches them statically. This
+test fails until every such bug is fixed — the same class the ctx-conversion
+surfaced.
+"""
+import glob
+import os
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TARGET_DIRS = [
+    "src/packs/core/commands",
+    "src/packs/core/spells",
+]
+
+
+def _pack_files():
+    files = []
+    for d in TARGET_DIRS:
+        files.extend(glob.glob(os.path.join(ROOT, d, "*.py")))
+    return sorted(f for f in files if not os.path.basename(f).startswith("__"))
+
+
+def test_no_undefined_names_in_pack_code():
+    files = _pack_files()
+    assert files, "no pack files found"
+    result = subprocess.run(
+        [sys.executable, "-m", "pyflakes", *files],
+        capture_output=True,
+        text=True,
+    )
+    undefined = [
+        line for line in result.stdout.splitlines() if "undefined name" in line
+    ]
+    assert not undefined, "undefined names (latent NameErrors) found:\n" + "\n".join(
+        line.replace(ROOT + "/", "") for line in undefined
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -466,6 +466,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyflakes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -627,6 +636,11 @@ dev = [
     { name = "ty" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyflakes" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.10.0" },
@@ -641,6 +655,9 @@ requires-dist = [
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.14" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyflakes", specifier = ">=3.4.0" }]
 
 [[package]]
 name = "rpds-py"


### PR DESCRIPTION
The ctx-style conversion surfaced a class of latent bugs — undefined names in command/spell bodies that only fire at call time (past import + most tests). Found statically with pyflakes and fixed, plus a guard test so they can't come back.

## Undefined names (latent NameErrors)
- **20 spells** used `instance` without importing it → added `from rom24 import instance`.
- `spell_detect_poison`: undefined `obj` → `obj = victim` (TAR_OBJ_INV target).
- `spell_create_water`: undefined `LIQ_WATER` → `0` (water is liq_table index 0).
- `spell_continual_light`: `item` → `light` (the looked-up object).
- `spell_heat_metal`: `dam` used before assignment → `dam = 0`.
- `spell_ventriloquate` (dead/unregistered): `target_name`/`is_exact_name` resolved.
- `do_log`: undefined `fLogAll` → module-level toggle + `global`.

## Logic bugs
- `spell_dispel_magic`: `found` referenced before assignment → init `found = False`.
- `do_pick`: `check_improve("pick_lock")` → `"pick lock"` (skill name mismatch).
- `do_oset`: `arg3.isdigit` → `arg3.isdigit()` (always-truthy method object).

## Guard
`tests/test_no_undefined_names.py` runs pyflakes over `packs/core` and fails on any undefined name (added `pyflakes` dev dep). It was red for all 36; now green.

57 tests pass; boots 48 areas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)