### PR TITLE
Deploy: LoadBalancer per env (MetalLB, same port 1337)

### DIFF
--- a/k8s/base/pyrom-service.yaml
+++ b/k8s/base/pyrom-service.yaml
@@ -10,5 +10,10 @@ spec:
       port: 1337
       targetPort: 1337
       name: telnet
-  type: ClusterIP
+  # LoadBalancer so each env gets its own MetalLB IP (all on 1337). The overlay
+  # pins the IP via the metallb.universe.tf/loadBalancerIPs annotation, and DNS
+  # points <env>-pyrom.bubtaylor.com at it. externalTrafficPolicy=Local keeps
+  # the real client IP (useful for MUD logging/bans).
+  type: LoadBalancer
+  externalTrafficPolicy: Local
 

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -13,6 +13,7 @@ commonLabels:
 patchesStrategicMerge:
   - ingress-patch.yaml
   - pyrom-configmap.yaml
+  - pyrom-service-patch.yaml
 
 images:
   - name: bubthegreat/pyrom

--- a/k8s/overlays/dev/pyrom-service-patch.yaml
+++ b/k8s/overlays/dev/pyrom-service-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pyrom-service
+  annotations:
+    # Pin this env's MetalLB LoadBalancer IP so DNS stays stable.
+    metallb.universe.tf/loadBalancerIPs: "192.168.0.43"

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -12,6 +12,7 @@ commonLabels:
 
 patchesStrategicMerge:
   - pyrom-configmap.yaml
+  - pyrom-service-patch.yaml
 
 images:
   - name: bubthegreat/pyrom

--- a/k8s/overlays/prod/pyrom-service-patch.yaml
+++ b/k8s/overlays/prod/pyrom-service-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pyrom-service
+  annotations:
+    # Pin this env's MetalLB LoadBalancer IP so DNS stays stable.
+    metallb.universe.tf/loadBalancerIPs: "192.168.0.42"

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -13,6 +13,7 @@ commonLabels:
 patchesStrategicMerge:
   - ingress-patch.yaml
   - pyrom-configmap.yaml
+  - pyrom-service-patch.yaml
 
 images:
   - name: bubthegreat/pyrom

--- a/k8s/overlays/staging/pyrom-service-patch.yaml
+++ b/k8s/overlays/staging/pyrom-service-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pyrom-service
+  annotations:
+    # Pin this env's MetalLB LoadBalancer IP so DNS stays stable.
+    metallb.universe.tf/loadBalancerIPs: "192.168.0.44"


### PR DESCRIPTION
Each env gets its own MetalLB LoadBalancer IP on port 1337 (prod .42 / dev .43 / staging .44), resolved by DNS (pyrom / dev-pyrom / staging-pyrom .bubtaylor.com). Replaces the port-offset ingress-nginx TCP design — telnet can't hostname-route. Service base ClusterIP->LoadBalancer + externalTrafficPolicy Local; overlays pin IPs via the MetalLB annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)